### PR TITLE
Ignore Eclipse configuration files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 nbproject
+/.settings/
+/.buildpath
+/.project


### PR DESCRIPTION
Avoid having a repository in an inconsistent state when importing the project into Eclipse
